### PR TITLE
Add the watchDirectory method to Inotify

### DIFF
--- a/include/notify-cpp/inotify.h
+++ b/include/notify-cpp/inotify.h
@@ -71,6 +71,7 @@ public:
     Inotify();
     ~Inotify();
     virtual void watchFile(const FileSystemEvent&) override;
+    virtual void watchDirectory(const FileSystemEvent&);
     virtual void unwatch(const FileSystemEvent&) override;
     virtual TFileSystemEventPtr getNextEvent() override;
     virtual std::uint32_t getEventMask(const Event) const override;

--- a/include/notify-cpp/notify_controller.h
+++ b/include/notify-cpp/notify_controller.h
@@ -27,6 +27,8 @@ public:
 
     NotifyController& watchFile(const FileSystemEvent&);
 
+    NotifyController& watchDirectory(const FileSystemEvent&);
+
     NotifyController& watchPathRecursively(const FileSystemEvent&);
 
     NotifyController& unwatch(const std::filesystem::path&);

--- a/source/inotify.cpp
+++ b/source/inotify.cpp
@@ -56,8 +56,7 @@ void Inotify::watchFile(const FileSystemEvent& fse)
         return;
 
     mError = 0;
-    int wd = 0;
-    wd = inotify_add_watch(mInotifyFd, fse.getPath().c_str(), getEventMask(fse.getEvent()));
+    const int wd = inotify_add_watch(mInotifyFd, fse.getPath().c_str(), getEventMask(fse.getEvent()));
 
     if (wd == -1) {
         mError = errno;
@@ -82,8 +81,7 @@ void Inotify::watchDirectory(const FileSystemEvent& fse)
         return;
 
     mError = 0;
-    int wd = 0;
-    wd = inotify_add_watch(mInotifyFd, fse.getPath().c_str(), getEventMask(fse.getEvent()));
+    const int wd = inotify_add_watch(mInotifyFd, fse.getPath().c_str(), getEventMask(fse.getEvent()));
 
     if (wd == -1) {
         mError = errno;

--- a/source/inotify.cpp
+++ b/source/inotify.cpp
@@ -76,6 +76,32 @@ void Inotify::watchFile(const FileSystemEvent& fse)
     mDirectorieMap.emplace(wd, fse.getPath());
 }
 
+void Inotify::watchDirectory(const FileSystemEvent& fse)
+{
+    if (!checkWatchDirectory(fse))
+        return;
+
+    mError = 0;
+    int wd = 0;
+    wd = inotify_add_watch(mInotifyFd, fse.getPath().c_str(), getEventMask(fse.getEvent()));
+
+    if (wd == -1) {
+        mError = errno;
+        std::stringstream errorStream;
+        if (mError == 28) {
+            errorStream << "Failed to watch! " << strerror(mError)
+                        << ". Please increase number of watches in "
+                           "\"/proc/sys/fs/inotify/max_user_watches\".";
+            throw std::runtime_error(errorStream.str());
+        }
+
+        errorStream << "Failed to watch! " << strerror(mError) << ". Path: " << fse.getPath();
+        throw std::runtime_error(errorStream.str());
+    }
+
+    mDirectorieMap.emplace(wd, fse.getPath());
+}
+
 void Inotify::unwatch(const FileSystemEvent& fse)
 {
     auto const itFound = std::find_if(

--- a/source/notify_controller.cpp
+++ b/source/notify_controller.cpp
@@ -56,6 +56,13 @@ NotifyController::watchFile(const FileSystemEvent& fse)
 }
 
 NotifyController&
+NotifyController::watchDirectory(const FileSystemEvent& fse)
+{
+    static_cast<Inotify*>(_Notify)->watchDirectory(fse);
+    return *this;
+}
+
+NotifyController&
 NotifyController::watchPathRecursively(const FileSystemEvent& fse)
 {
     _Notify->watchPathRecursively(fse);


### PR DESCRIPTION
I needed to be able to get the events from a directory and realized a bit late that that method wasn't available so I added it myself. I think I kept the code style pretty similar to what was already there. If there was another way to get the events of a directory directly I would also like to hear that.

I would be open to processing some comments if you have them.